### PR TITLE
Use ISNAN() to prevent build error on OS X 10.7

### DIFF
--- a/src/MyBinding.h
+++ b/src/MyBinding.h
@@ -97,7 +97,7 @@ public:
       }
       case MY_DATE:
       case MY_DATE_TIME:
-        if (isnan(REAL(col)[i])) {
+        if (ISNAN(REAL(col)[i])) {
           missing = true;
           break;
         } else {


### PR DESCRIPTION
Replace isnan() with R's ISNAN(), as described in Writing R Extensions:

> Functions/macros such as isnan, isinf and isfinite are not required by
> C++98: where compilers support them they may be only in the std
> namespace or only in the main namespace. There is no way to make use
> of these functions which works with all C++ compilers currently in use
> on R platforms: use R’s versions such as ISNAN and R_FINITE instead.
> -- [R Core Team,Writing R Extensions: Portable C and C++ code](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Portable-C-and-C_002b_002b-code)

This prevents the following error when trying to build RMySQL on my
Mac OS X 10.7:

```
MyBinding.h:100: error: ‘isnan’ was not declared in this scope
```

Further reading:
- https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Portable-C-and-C_002b_002b-code
- https://stat.ethz.ch/pipermail/r-devel/2005-January/thread.html#31793
- https://stat.ethz.ch/pipermail/r-devel/2005-January/thread.html#31800
- http://lists.apple.com/archives/Xcode-users/2006/Aug/thrd7.html#00619
- http://lists.apple.com/archives/Xcode-users/2006/Aug/thrd7.html#00633
- http://stackoverflow.com/questions/18128899/is-isnan-in-the-std-namespace-more-in-general-when-is-std-necessary-optio
- http://stackoverflow.com/questions/2249110/how-do-i-make-a-portable-isnan-isinf-function
- http://stackoverflow.com/questions/570669/checking-if-a-double-or-float-is-nan-in-c
